### PR TITLE
Redirect to a URL that always has the same base

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -5,13 +5,14 @@
 # For an explanation of the hack with the addSlash function for redirects without trailing slash, see https://answers.netlify.com/t/bug-in-non-trailing-slash-rewrite/452/39
 
 /current_doxygen    /.netlify/functions/addSlash  200
-/current_doxygen/*  https://abibuilder.cs.uni-tuebingen.de/archive/openms/Documentation/release/latest/:splat  200
+/current_doxygen/*  /doxygen/release/latest/:splat  200
+
+/develop_doxygen.   /.netlify/functions/addSlash  200
+/develop_doxygen/*  /doxygen/nightly/:splat  200
 
 /documentation      /.netlify/functions/addSlash  200
-/documentation/*    https://abibuilder.cs.uni-tuebingen.de/archive/openms/Documentation/release/latest/:splat  200
+/documentation/*    /doxygen/release/latest/:splat  200
 
-/develop_doxygen    /.netlify/functions/addSlash  200
-/develop_doxygen/*  https://abibuilder.cs.uni-tuebingen.de/archive/openms/Documentation/nightly/:splat  200
 
 ## should never be called as openms.de/doxygen. Only to be used as openms.de/doxygen/release/2.9.0 for example.
 /doxygen/*          https://abibuilder.cs.uni-tuebingen.de/archive/openms/Documentation/:splat  200


### PR DESCRIPTION
#### Brief description of what is fixed or changed

Always redirect to /doxygen/... which then redirects to our archive.
Prerequisite for version selector on our API docs when accessing from openms.de

https://github.com/OpenMS/OpenMS/commit/27ae821b1e163f18d44668dedba6b335fc6a47e0
https://github.com/OpenMS/OpenMS/issues/6003
<!-- If this pull request fixes an issue, write "Fixes gh-NNNN" in that exact
format, e.g. "Fixes gh-1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open.

OR/AND

Describe your changes here
-->

