### PR TITLE
redirects for KNIME

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -7,8 +7,9 @@
 /current_doxygen    /.netlify/functions/addSlash  200
 /current_doxygen/*  https://abibuilder.cs.uni-tuebingen.de/archive/openms/Documentation/release/latest/:splat  200
 
-/documentation      /.netlify/functions/addSlash  200
-/documentation/*    https://abibuilder.cs.uni-tuebingen.de/archive/openms/Documentation/release/latest/:splat  200
+/documentation         /.netlify/functions/addSlash  200
+/documentation/html/*  https://abibuilder.cs.uni-tuebingen.de/archive/openms/Documentation/release/latest/html/:splat  200
+/documentation/*       https://abibuilder.cs.uni-tuebingen.de/archive/openms/Documentation/release/latest/html/:splat  200
 
 /develop_doxygen    /.netlify/functions/addSlash  200
 /develop_doxygen/*  https://abibuilder.cs.uni-tuebingen.de/archive/openms/Documentation/nightly/:splat  200


### PR DESCRIPTION
open the help page for TOPP Tools in KNIME: it tries to access https://openms.de/documentation/TOPP_InternalCalibration.html which should redirect to
 https://openms.de/documentation/html/TOPP_InternalCalibration.html





