### PR TITLE
Added denbi logo to dev meeting

### DIFF
--- a/content/en/news/devmeeting2024.md
+++ b/content/en/news/devmeeting2024.md
@@ -6,3 +6,5 @@ summary: We are hosting a developers conference near Malaga, Spain! Click the he
 ---
 
 The OpenMS developers conference brings together people working in computational mass spectrometry to shape the future development of OpenMS. It is targeted to core developers, new developers, and potential future contributors. Short talks, developer tutorials, and code sprints will be intertwined. Participants will have the opportunity to design custom tools and workflows together with instructors. New developers will receive help getting started in OpenMS development. Progress will be tracked on our GitHub page with a resume of each day. For more details ping Tjeerd Dijkstra or Timo Sachsenberg on discord or by email.
+<br><br>
+![denbi](/images/logos/denbi.jpeg)


### PR DESCRIPTION
Adding the logo to the news banner in the main page seems to be a bit difficult & we probably would need to change some layouts in the hugo theme. I think this solution is much easier and might be sufficient already. The logo is only displayed on the single page of the news for the dev meeting.
#### Brief description of what is fixed or changed

<!-- If this pull request fixes an issue, write "Fixes gh-NNNN" in that exact
format, e.g. "Fixes gh-1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open.

OR/AND

Describe your changes here
-->

