### PR TITLE
User meeting 2024 news item

### DIFF
--- a/content/en/news/usermeeting2024.md
+++ b/content/en/news/usermeeting2024.md
@@ -1,0 +1,10 @@
+---
+title: OpenMS Users Meeting 17-18 October 2024, in Berlin, Germany
+authors: ["Tjeerd Dijkstra, Timo Sachsenberg"]
+date: 2024-05-21
+summary: We are organizing a users meeting in Berlin, Germany! Click the header above for more information.
+---
+
+The OpenMS developers conference brings together people working in computational mass spectrometry to shape the future development of OpenMS. It is targeted to core developers, new developers, and potential future contributors. Short talks, developer tutorials, and code sprints will be intertwined. Participants will have the opportunity to design custom tools and workflows together with instructors. New developers will receive help getting started in OpenMS development. Progress will be tracked on our GitHub page with a resume of each day. For more details ping Tjeerd Dijkstra or Timo Sachsenberg on discord or by email.
+<br><br>
+![denbi](/images/logos/denbi.jpeg)

--- a/content/en/news/usermeeting2024.md
+++ b/content/en/news/usermeeting2024.md
@@ -5,6 +5,18 @@ date: 2024-05-21
 summary: We are organizing a users meeting in Berlin, Germany! Click the header above for more information.
 ---
 
-The OpenMS developers conference brings together people working in computational mass spectrometry to shape the future development of OpenMS. It is targeted to core developers, new developers, and potential future contributors. Short talks, developer tutorials, and code sprints will be intertwined. Participants will have the opportunity to design custom tools and workflows together with instructors. New developers will receive help getting started in OpenMS development. Progress will be tracked on our GitHub page with a resume of each day. For more details ping Tjeerd Dijkstra or Timo Sachsenberg on discord or by email.
+We are pleased to announce the 2024 OpenMS User Meeting.
+When:  17 and 18 October 2024
+Where: KNIME GmbH, Körtestr. 10, 10967 Berlin, Germany
+What:
+1.	Basic Introduction to Data Analysis with OpenMS (2 days, 17-18 Oct) led by Sam Wein
+2.	Advanced Tutorial: programming with pyOpenMS (1 day, 17 Oct) led by Matteo Pilz
+3.	Advanced Tutorial: web-apps with OpenMS (1 day, 18 Oct) led by Axel Walter
+4.	Advanced Tutorial: top-down proteomics with OpenMS (1 day, 17 Oct) led by Kyowon Jeong
+5.	Advanced Tutorial: DIA Proteomics with OpenSwath/OpenMS (1 day, 18 Oct) led by Joshua Charkow
+
+Registration is 200 Euros for Thursday the 17th (including coffee/tea, lunch, dinner and poster session), 150 Euros for Friday the 18th (including coffee/tea and lunch) and 300 Euros for both days combined.
+The Meeting is planned such that one can attend the OpenMS User Meeting in Berlin 17-18 October and [HUPO](https://2024.hupo.org) in Dresden 20-24 October 2024
+Registration form is here: https://docs.google.com/forms/d/1hGBNNXHtxGyk6MO6EiKHNhbrPbklLhBnAqKwZ2O-ZuU
 <br><br>
 ![denbi](/images/logos/denbi.jpeg)

--- a/content/en/news/usermeeting2024.md
+++ b/content/en/news/usermeeting2024.md
@@ -17,6 +17,6 @@ What:
 
 Registration is 200 Euros for Thursday the 17th (including coffee/tea, lunch, dinner and poster session), 150 Euros for Friday the 18th (including coffee/tea and lunch) and 300 Euros for both days combined.
 The Meeting is planned such that one can attend the OpenMS User Meeting in Berlin 17-18 October and [HUPO](https://2024.hupo.org) in Dresden 20-24 October 2024
-Registration form is here: https://docs.google.com/forms/d/1hGBNNXHtxGyk6MO6EiKHNhbrPbklLhBnAqKwZ2O-ZuU
++[Click here to register](https://docs.google.com/forms/d/1hGBNNXHtxGyk6MO6EiKHNhbrPbklLhBnAqKwZ2O-ZuU)
 <br><br>
 ![denbi](/images/logos/denbi.jpeg)

--- a/content/en/news/usermeeting2024.md
+++ b/content/en/news/usermeeting2024.md
@@ -17,6 +17,7 @@ What:
 
 Registration is 200 Euros for Thursday the 17th (including coffee/tea, lunch, dinner and poster session), 150 Euros for Friday the 18th (including coffee/tea and lunch) and 300 Euros for both days combined.
 The Meeting is planned such that one can attend the OpenMS User Meeting in Berlin 17-18 October and [HUPO](https://2024.hupo.org) in Dresden 20-24 October 2024
-+[Click here to register](https://docs.google.com/forms/d/1hGBNNXHtxGyk6MO6EiKHNhbrPbklLhBnAqKwZ2O-ZuU)
+<br>
+[Click here to register](https://docs.google.com/forms/d/1hGBNNXHtxGyk6MO6EiKHNhbrPbklLhBnAqKwZ2O-ZuU)
 <br><br>
 ![denbi](/images/logos/denbi.jpeg)

--- a/content/en/news/usermeeting2024.md
+++ b/content/en/news/usermeeting2024.md
@@ -5,9 +5,9 @@ date: 2024-05-21
 summary: We are organizing a users meeting in Berlin, Germany! Click the header above for more information.
 ---
 
-We are pleased to announce the 2024 OpenMS User Meeting.
-When:  17 and 18 October 2024
-Where: KNIME GmbH, Körtestr. 10, 10967 Berlin, Germany
+We are pleased to announce the 2024 OpenMS User Meeting.<br>
+When:  17 and 18 October 2024<br>
+Where: KNIME GmbH, Körtestr. 10, 10967 Berlin, Germany<br>
 What:
 1.	Basic Introduction to Data Analysis with OpenMS (2 days, 17-18 Oct) led by Sam Wein
 2.	Advanced Tutorial: programming with pyOpenMS (1 day, 17 Oct) led by Matteo Pilz


### PR DESCRIPTION
### **User description**
Updated text of news item


___

### **PR Type**
documentation


___

### **Description**
- Added a new news item announcing the OpenMS User Meeting on 17-18 October 2024 in Berlin, Germany.
- Included detailed information about the event schedule, including tutorials and their respective leaders.
- Provided registration costs and a link to the registration form.
- Added an image related to the event.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>usermeeting2024.md</strong><dd><code>Added announcement for OpenMS User Meeting 2024.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
content/en/news/usermeeting2024.md

<li>Added a new news item announcing the OpenMS User Meeting in October <br>2024.<br> <li> Included details about the event such as dates, location, agenda, and <br>registration information.<br> <li> Provided a link to the registration form and an image.<br>


</details>
    

  </td>
  <td><a href="https://github.com/OpenMS/OpenMS-website/pull/139/files#diff-b20876aab3b7dbf9349c3df4baf1f7ca2e3b7dcad989613ae654d8309c3fcd52">+22/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

