### PR TITLE
Update usermeeting2024.md

### DIFF
--- a/content/en/news/usermeeting2024.md
+++ b/content/en/news/usermeeting2024.md
@@ -16,10 +16,10 @@ What:
 5.	Advanced Tutorial: DIA proteomics with OpenSwath/OpenMS (1 day, 18 Oct) led by Joshua Charkow.
 
 Registration is 200 Euros for Thursday the 17th (including coffee/tea, lunch, dinner and poster session), 150 Euros for Friday the 18th (including coffee/tea and lunch) and 300 Euros for both days combined.<br>
-The meeting is planned such that one can attend the OpenMS user meeting in Berlin 17-18 October and [HUPO](https://2024.hupo.org) in Dresden 20-24 October 2024.
+The meeting is planned such that one can attend the OpenMS user meeting in Berlin 17-18 October and [HUPO](https://2024.hupo.org) in Dresden 20-24 October 2024. Note that HUPO requires separate registration.
 <br>
 [Click here to register](https://docs.google.com/forms/d/1hGBNNXHtxGyk6MO6EiKHNhbrPbklLhBnAqKwZ2O-ZuU)
 <br><br>
 ![denbi](/images/logos/denbi.jpeg) &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; ![elixir](/images/logos/Elixir.png)
 <br><br>
-![hupo](/images/logos/HUPO-2024.jpg)
+[![hupo](/images/logos/HUPO-2024.jpg)](https://2024.hupo.org)


### PR DESCRIPTION
### **User description**
Update HUPO references and add text that HUPO requires a separate registration



#### Brief description of what is fixed or changed

<!-- If this pull request fixes an issue, write "Fixes gh-NNNN" in that exact
format, e.g. "Fixes gh-1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open.

OR/AND

Describe your changes here
-->


___

### **PR Type**
Documentation


___

### **Description**
- Added a note indicating that HUPO requires separate registration.
- Made the HUPO image a clickable link to the HUPO 2024 website.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>usermeeting2024.md</strong><dd><code>Update HUPO registration details and link image</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
content/en/news/usermeeting2024.md

<li>Added note about separate registration for HUPO.<br> <li> Made HUPO image a clickable link.<br>


</details>
    

  </td>
  <td><a href="https://github.com/OpenMS/OpenMS-website/pull/146/files#diff-b20876aab3b7dbf9349c3df4baf1f7ca2e3b7dcad989613ae654d8309c3fcd52">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

