### PR TITLE
Update usermeeting2024.md

### DIFF
--- a/content/en/news/usermeeting2024.md
+++ b/content/en/news/usermeeting2024.md
@@ -10,12 +10,12 @@ When:  17 and 18 October 2024.<br>
 Where: KNIME GmbH, Körtestr. 10, 10967 Berlin, Germany.<br>
 What:
 1.	Basic introduction to data analysis with OpenMS (2 days, 17-18 Oct) led by Sam Wein.
-2.	Advanced Tutorial: programming with pyOpenMS (1 day, 17 Oct) led by Matteo Pilz.
-3.	Advanced Tutorial: web-apps with OpenMS (1 day, 18 Oct) led by Axel Walter.
-4.	Advanced Tutorial: top-down proteomics with OpenMS (1 day, 17 Oct) led by Kyowon Jeong.
-5.	Advanced Tutorial: DIA proteomics with OpenSwath/OpenMS (1 day, 18 Oct) led by Joshua Charkow.
+2.	Advanced Tutorial: pyOpenMS and web-apps (1 day, 17 Oct) led by Matteo Pilz and Axel Walter.
+3.	Advanced Tutorial: top-down proteomics with OpenMS (1 day, 17 Oct) led by Kyowon Jeong.
+4.	Advanced Tutorial: DIA proteomics with OpenSwath/OpenMS (1 day, 18 Oct) led by Joshua Charkow.
 
 Registration is 200 Euros for Thursday the 17th (including coffee/tea, lunch, dinner and poster session), 150 Euros for Friday the 18th (including coffee/tea and lunch) and 300 Euros for both days combined.<br>
+After 1 September 2024, registration fees are 250 Euros for Thursday the 17th, 200 Euros for Friday the 18th and 400 Euros for both days combined.<br>
 The meeting is planned such that one can attend the OpenMS user meeting in Berlin 17-18 October and [HUPO](https://2024.hupo.org) in Dresden 20-24 October 2024. Note that HUPO requires separate registration.
 <br>
 [Click here to register](https://docs.google.com/forms/d/1hGBNNXHtxGyk6MO6EiKHNhbrPbklLhBnAqKwZ2O-ZuU)


### PR DESCRIPTION
### **User description**
Merged pyOpenMS and web-apps tutorials per Matteo's and Axel's request. Added 1 Sep 2024 date as cut-off for early registration.



#### Brief description of what is fixed or changed

<!-- If this pull request fixes an issue, write "Fixes gh-NNNN" in that exact
format, e.g. "Fixes gh-1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open.

OR/AND

Describe your changes here
-->


___

### **PR Type**
Documentation


___

### **Description**
- Merged `pyOpenMS` and `web-apps` tutorials into a single session as per Matteo's and Axel's request.
- Added 1 September 2024 as the cut-off date for early registration.
- Updated registration fees for after the cut-off date.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>usermeeting2024.md</strong><dd><code>Update user meeting details and registration information</code>&nbsp; </dd></summary>
<hr>
      
content/en/news/usermeeting2024.md

<li>Merged <code>pyOpenMS</code> and <code>web-apps</code> tutorials into a single session.<br> <li> Added a new date (1 Sep 2024) as the cut-off for early registration.<br> <li> Updated registration fees after the cut-off date.<br>


</details>
    

  </td>
  <td><a href="https://github.com/OpenMS/OpenMS-website/pull/147/files#diff-b20876aab3b7dbf9349c3df4baf1f7ca2e3b7dcad989613ae654d8309c3fcd52">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

