### PR TITLE
Fix GSCO2025 Display

### DIFF
--- a/content/en/news/GSoC2025.md
+++ b/content/en/news/GSoC2025.md
@@ -170,7 +170,9 @@ This project offers an exciting opportunity to apply deep learning & generative 
 ### 7) Peptide m/z calculator
 
 **Proposed Mentors:** Arslan Siraj, Tom Müller
+
 **Skills:** Python, Git, Streamlit
+
 **Estimated Project Length:** 90 hours | Difficulty: Easy
 
 In mass spectrometry (MS) proteomics and metabolomics, one common task is to compute the mass-to-charge (m/z) ratio of the analyte so that it can be located in a spectrum. Although the calculation is computationally simple and can easily be performed by the pyopenms package, this simple, commonly used calculation can be cumbersome for wet lab scientists with little programming experience. In this project the student will use the new OpenMS-WebApps template (https://pubs.acs.org/doi/10.1021/acs.jproteome.4c00872) to create a simple GUI to allow for researchers to perform this calculation. This calculation can be performed using pyopenms as demonstrated here https://pyopenms.readthedocs.io/en/latest/user_guide/peptides_proteins.html. Furthermore, this outcome web application further can be extend to other MS calculations tasks (e-g theoretical spectra generation etc) for quick interpretation of MS data.
@@ -180,7 +182,9 @@ In mass spectrometry (MS) proteomics and metabolomics, one common task is to com
 ### 8) Pythonic mzML handling
 
 **Proposed Mentors:** Joshua Charkow, Tom Müller
+
 **Skills:** Python, Git
+
 **Estimated Project Length:** 175 hours | Difficulty: Easy
 
 Liquid-Chromatography-Mass Spectrometry data is commonly stored in sparse multidimensional data containing billions of peaks and can easily exceed a few gigabytes when compressed on disk. Python is commonly used in the field for exploratory analysis and development of novel data processing algorithms. The most common format for storing mass spectrometry data is in .mzML, an XML based format  Although numerous libraries exist for parsing .mzML files in Python, an open source XML based format most commonly used in the field, each library contains its own UI which might not be intuitive for data scientists just starting with mass spectrometry.  Recently, the alphatims package (https://github.com/MannLabs/alphatims) was introduced which stores mass spectrometry data in a pandas dataframe like structure making it quite accessible data manipulation and exploration. Notably, this format takes advantage of python’s slicing syntax making it intuitive for all data scientists. However, this package only supports “.d” files which are vendor specific and not applicable to the broader mass spectrometry community. In this project, the student will create a “pythonic” .mzML file reader inspired by alphatims by extending the current available .mzML python parsers. This will involve 1) Using the pyopenms documentation to get familiar with pyopenms .mzML file reading. 2) Creating a class which allows for splicing of the .mzML file across various dimensions and returning a DataFrame object. 3) Benchmarking this class on various .mzML files for read times and memory usage.  4) creating a python package and releasing it on PyPI.
@@ -190,7 +194,9 @@ Liquid-Chromatography-Mass Spectrometry data is commonly stored in sparse multid
 ### 9) Improving PyOpenMS Tool Parameter Accessibility
 
 **Proposed Mentors:** Tom Müller, Joshua Charkow
+
 **Skills:** Python, Cython, Git
+
 **Estimated Project Length:** 175 hours | Difficulty: Medium
 
 PyOpenMS provides Python bindings for OpenMS, a powerful open-source C++ library for computational mass spectrometry. These bindings are automatically generated using Cython and the autowrap package. While C++ developers prioritize performance and fine-grained control, Python developers emphasize readability and ease of use. Simply exposing a C++ API to Python often results in an interface that feels unnatural to Python users.

--- a/content/en/news/GSoC2025.md
+++ b/content/en/news/GSoC2025.md
@@ -168,6 +168,7 @@ This project offers an exciting opportunity to apply deep learning & generative 
 ---
 
 ### 7) Peptide m/z calculator
+
 **Proposed Mentors:** Arslan Siraj, Tom Müller
 **Skills:** Python, Git, Streamlit
 **Estimated Project Length:** 90 hours | Difficulty: Easy
@@ -175,6 +176,7 @@ This project offers an exciting opportunity to apply deep learning & generative 
 In mass spectrometry (MS) proteomics and metabolomics, one common task is to compute the mass-to-charge (m/z) ratio of the analyte so that it can be located in a spectrum. Although the calculation is computationally simple and can easily be performed by the pyopenms package, this simple, commonly used calculation can be cumbersome for wet lab scientists with little programming experience. In this project the student will use the new OpenMS-WebApps template (https://pubs.acs.org/doi/10.1021/acs.jproteome.4c00872) to create a simple GUI to allow for researchers to perform this calculation. This calculation can be performed using pyopenms as demonstrated here https://pyopenms.readthedocs.io/en/latest/user_guide/peptides_proteins.html. Furthermore, this outcome web application further can be extend to other MS calculations tasks (e-g theoretical spectra generation etc) for quick interpretation of MS data.
 
 ### 8) Pythonic mzML handling
+
 **Proposed Mentors:** Joshua Charkow, Tom Müller
 **Skills:** Python, Git
 **Estimated Project Length:** 175 hours | Difficulty: Easy
@@ -182,6 +184,7 @@ In mass spectrometry (MS) proteomics and metabolomics, one common task is to com
 Liquid-Chromatography-Mass Spectrometry data is commonly stored in sparse multidimensional data containing billions of peaks and can easily exceed a few gigabytes when compressed on disk. Python is commonly used in the field for exploratory analysis and development of novel data processing algorithms. The most common format for storing mass spectrometry data is in .mzML, an XML based format  Although numerous libraries exist for parsing .mzML files in Python, an open source XML based format most commonly used in the field, each library contains its own UI which might not be intuitive for data scientists just starting with mass spectrometry.  Recently, the alphatims package (https://github.com/MannLabs/alphatims) was introduced which stores mass spectrometry data in a pandas dataframe like structure making it quite accessible data manipulation and exploration. Notably, this format takes advantage of python’s slicing syntax making it intuitive for all data scientists. However, this package only supports “.d” files which are vendor specific and not applicable to the broader mass spectrometry community. In this project, the student will create a “pythonic” .mzML file reader inspired by alphatims by extending the current available .mzML python parsers. This will involve 1) Using the pyopenms documentation to get familiar with pyopenms .mzML file reading. 2) Creating a class which allows for splicing of the .mzML file across various dimensions and returning a DataFrame object. 3) Benchmarking this class on various .mzML files for read times and memory usage.  4) creating a python package and releasing it on PyPI.
 
 ### 9) Improving PyOpenMS Tool Parameter Accessibility
+
 **Proposed Mentors:** Tom Müller, Joshua Charkow
 **Skills:** Python, Cython, Git 
 **Estimated Project Length:** 175 hours | Difficulty: Medium

--- a/content/en/news/GSoC2025.md
+++ b/content/en/news/GSoC2025.md
@@ -175,6 +175,8 @@ This project offers an exciting opportunity to apply deep learning & generative 
 
 In mass spectrometry (MS) proteomics and metabolomics, one common task is to compute the mass-to-charge (m/z) ratio of the analyte so that it can be located in a spectrum. Although the calculation is computationally simple and can easily be performed by the pyopenms package, this simple, commonly used calculation can be cumbersome for wet lab scientists with little programming experience. In this project the student will use the new OpenMS-WebApps template (https://pubs.acs.org/doi/10.1021/acs.jproteome.4c00872) to create a simple GUI to allow for researchers to perform this calculation. This calculation can be performed using pyopenms as demonstrated here https://pyopenms.readthedocs.io/en/latest/user_guide/peptides_proteins.html. Furthermore, this outcome web application further can be extend to other MS calculations tasks (e-g theoretical spectra generation etc) for quick interpretation of MS data.
 
+---
+
 ### 8) Pythonic mzML handling
 
 **Proposed Mentors:** Joshua Charkow, Tom Müller
@@ -183,10 +185,12 @@ In mass spectrometry (MS) proteomics and metabolomics, one common task is to com
 
 Liquid-Chromatography-Mass Spectrometry data is commonly stored in sparse multidimensional data containing billions of peaks and can easily exceed a few gigabytes when compressed on disk. Python is commonly used in the field for exploratory analysis and development of novel data processing algorithms. The most common format for storing mass spectrometry data is in .mzML, an XML based format  Although numerous libraries exist for parsing .mzML files in Python, an open source XML based format most commonly used in the field, each library contains its own UI which might not be intuitive for data scientists just starting with mass spectrometry.  Recently, the alphatims package (https://github.com/MannLabs/alphatims) was introduced which stores mass spectrometry data in a pandas dataframe like structure making it quite accessible data manipulation and exploration. Notably, this format takes advantage of python’s slicing syntax making it intuitive for all data scientists. However, this package only supports “.d” files which are vendor specific and not applicable to the broader mass spectrometry community. In this project, the student will create a “pythonic” .mzML file reader inspired by alphatims by extending the current available .mzML python parsers. This will involve 1) Using the pyopenms documentation to get familiar with pyopenms .mzML file reading. 2) Creating a class which allows for splicing of the .mzML file across various dimensions and returning a DataFrame object. 3) Benchmarking this class on various .mzML files for read times and memory usage.  4) creating a python package and releasing it on PyPI.
 
+---
+
 ### 9) Improving PyOpenMS Tool Parameter Accessibility
 
 **Proposed Mentors:** Tom Müller, Joshua Charkow
-**Skills:** Python, Cython, Git 
+**Skills:** Python, Cython, Git
 **Estimated Project Length:** 175 hours | Difficulty: Medium
 
 PyOpenMS provides Python bindings for OpenMS, a powerful open-source C++ library for computational mass spectrometry. These bindings are automatically generated using Cython and the autowrap package. While C++ developers prioritize performance and fine-grained control, Python developers emphasize readability and ease of use. Simply exposing a C++ API to Python often results in an interface that feels unnatural to Python users.


### PR DESCRIPTION
This PR adds newlines to fix the display of mentors, skills, and estimated project length for some GSOC projects.

#### Brief description of what is fixed or changed

<!-- If this pull request fixes an issue, write "Fixes gh-NNNN" in that exact
format, e.g. "Fixes gh-1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open.

OR/AND

Describe your changes here
-->

