### PR TITLE
Fixes gh-186

### DIFF
--- a/layouts/_internal/google_analytics_async.html
+++ b/layouts/_internal/google_analytics_async.html
@@ -1,0 +1,22 @@
+{{ if not site.Config.Privacy.GoogleAnalytics.Disable }}
+  {{- with site.Config.Services.GoogleAnalytics.ID }}
+    {{- if strings.HasPrefix (lower .) "ua-" }}
+      {{- warnf "Google Analytics 4 (GA4) replaced Google Universal Analytics (UA) effective 1 July 2023. See https://support.google.com/analytics/answer/11583528. Create a GA4 property and data stream, then replace the Google Analytics ID in your site configuration with the new value." }}
+    {{- else }}
+      <script async src="https://www.googletagmanager.com/gtag/js?id={{ . }}"></script>
+      <script>
+        var doNotTrack = false;
+        if ({{ site.Config.Privacy.GoogleAnalytics.RespectDoNotTrack }}) {
+          var dnt = (navigator.doNotTrack || window.doNotTrack || navigator.msDoNotTrack);
+          var doNotTrack = (dnt == "1" || dnt == "yes");
+        }
+        if (!doNotTrack) {
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', '{{ . }}');
+        }
+      </script>
+    {{- end }}
+  {{- end }}
+{{- end -}}

--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -1,9 +1,8 @@
 <!-- Include all theme CSS filenames here -->
 {{- $page := . -}}
 
-{{- $inServerMode := .Site.IsServer -}}
 {{- $sass         := (slice "theme-css/fresh/core.scss") -}}
-{{- $cssOpts      := cond ($inServerMode) (dict "enableSourceMap" true) (dict "outputStyle" "compressed") -}}
+{{- $cssOpts      := dict "outputStyle" "compressed" -}}
 
 <!-- Fonts -->
 <!-- {{- $fontName     := .Site.Params.font.name | default "Open Sans" -}}
@@ -18,15 +17,8 @@
 
 <!-- SASS --- currently only for fresh -->
 {{- range $sass -}}
-
-{{- if $inServerMode -}}
-{{ $css := resources.Get . | toCSS $cssOpts -}}
-<link rel="stylesheet" type="text/css" href="{{ $css.RelPermalink }}">
-{{ else }}
 {{ $css := resources.Get . | toCSS $cssOpts | minify | fingerprint -}}
 <link rel="stylesheet" type="text/css" href="{{ $css.RelPermalink }}" integrity="{{ $css.Data.Integrity }}">
-{{- end -}}
-
 {{- end -}}
 
 {{- $themeCssFiles := resources.Match "theme-css/*.css" -}}
@@ -34,15 +26,7 @@
 {{- $cssFiles := $themeCssFiles | append $userCssFiles }}
 
 {{- range $cssFiles -}}
-
 {{- $targetFile := printf "css/%s.css" . -}}
-
-{{ if $inServerMode -}}
-{{ $custom_style := . | resources.ExecuteAsTemplate $targetFile $page -}}
-<link rel="stylesheet" href="{{ $custom_style.RelPermalink }}">
-{{ else }}
 {{ $custom_style := . | resources.ExecuteAsTemplate $targetFile $page | minify | fingerprint -}}
 <link rel="stylesheet" href="{{ $custom_style.RelPermalink }}" integrity="{{ $custom_style.Data.Integrity }}">
-{{- end -}}
-
 {{- end -}}


### PR DESCRIPTION

#### Brief description of what is fixed or changed

<!-- If this pull request fixes an issue, write "Fixes gh-NNNN" in that exact
format, e.g. "Fixes gh-1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open.

OR/AND

Describe your changes here
-->
Added Google Analytics as an internal template. Pasted the template in `layouts/_internal/google_analytics_async.html`
can be found here: https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/google_analytics.html

Also Fixed the .isServerMode error. Removed the .IsServer Check from all the templates codes.This typically doesnt impact the site much (as production builds will not be impacted at all and hugo serve development builds will typically only be changed slightly) 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced asynchronous analytics tracking that respects user privacy settings (e.g., Do Not Track) and alerts users when outdated tracking configurations are detected.
  
- **Refactor**
  - Standardized the styling process to consistently produce compressed and fingerprinted CSS, enhancing site performance and maintainability.
  
- **Chores**
  - Updated the site theme to incorporate the latest improvements and enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->